### PR TITLE
Associating with *.twig files

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,7 +41,7 @@
         LanguageManager.defineLanguage("twigmixed", {
             name: "Twig",
             mode: "twigmixed",
-            fileExtensions: ["html.twig", "twig.html"]
+            fileExtensions: ["html.twig", "twig.html", ".twig"]
         })
         .done(function (twig) {
             twig._setLanguageForMode("twig:inner", twig);


### PR DESCRIPTION
I needed to make this edit in my local installation, brackets wasn't adding the plugin as the default language for *.twig files.

Simple, but might be useful, so I decided to contribute.
